### PR TITLE
Enforce config.json validation and remove the need to update Config.tsx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json ./
 COPY package-lock.json ./
 COPY src ./src
+COPY scripts ./scripts
 COPY public ./public
 COPY tsconfig.json ./tsconfig.json
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "path-browserify": "^1.0.1",
     "process": "^0.11.10",
     "querystring-es3": "^0.2.1",
+    "react-scripts": "^4.0.3",
     "stream-browserify": "^3.0.0",
     "stream-http": "^3.2.0",
     "url": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/react-dom": "^18.0.6",
     "axios": "^0.26.1",
     "bootstrap": "^5.1.3",
+    "chalk": "^4.1.2",
     "cors": "^2.8.5",
     "html-react-parser": "^1.4.8",
     "react": "^18.2.0",
@@ -47,9 +48,10 @@
   },
   "scripts": {
     "start": "react-scripts start",
-    "build": "react-scripts build",
+    "build": "npm run check-config && react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "check-config": "node ./scripts/configChecker.js"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/configChecker.js
+++ b/scripts/configChecker.js
@@ -1,0 +1,131 @@
+const fs = require('fs');
+const path = require('path');
+const { execSync } = require('child_process')
+const chalk = require('chalk');
+const { NetworkType } = require("@airgap/beacon-sdk");
+
+console.log(chalk.cyan("Validating src/config.json file...\n"));
+
+function err(msg) {
+  console.log(chalk.bold.red(msg));
+
+  process.exit(1);
+}
+
+function warn(msg) {
+  console.log(chalk.yellow(msg));
+}
+
+function isVersionStable(version) {
+  return version.indexOf("rc") === -1 && version.indexOf("beta") === -1;
+}
+
+function checkForNPMPackageUpdate(_package) {
+  let installed = undefined;
+
+  const npmls = execSync(`npm list ${_package} --depth=0`).toLocaleString();
+  const pkgVersionPrefix = `${_package}@`;
+  const packageIndex = npmls.indexOf(pkgVersionPrefix);
+  if (packageIndex > -1) {
+    installed = npmls.substring(packageIndex + pkgVersionPrefix.length).trim();
+  }
+  
+  const available = JSON.parse(execSync(`npm show ${_package} versions`).toLocaleString().replace(/'/g, "\""));
+  let latestVersion = available[available.length - 1];
+
+  const stableVersions = available.filter(x => isVersionStable(x));
+  if (stableVersions && stableVersions.length > 0) {
+    latestVersion = stableVersions[stableVersions.length - 1];
+  }
+
+  return {
+    installed,
+    latestVersion,
+  }
+}
+
+function versionLtThan(version, than) {
+  if (version === than) {
+    return false;
+  }
+
+  if (!isVersionStable(version) || !isVersionStable(than)) {
+    return null;
+  }
+
+  const versionComponents = version.split(".");
+  const thanComponents = than.split(".");
+
+  let versionComponent, thanComponent = 0;
+  for (let i=0; i<versionComponents.length; i++) {
+    versionComponent = parseInt(versionComponents[i], 10);
+    thanComponent = parseInt(thanComponents[i], 10);
+    
+    if (isNaN(versionComponent) || isNaN(thanComponent)) {
+      return null;
+    }
+
+    if (versionComponent < thanComponent) {
+      return true;
+    } else if (versionComponent > thanComponent) {
+      return false;
+    } // else if (versionComponanent === thanComponent) { continue; }
+  }
+
+  return false;
+}
+
+function suggestEventualPackageUpdate(_package) {
+  const pkg = checkForNPMPackageUpdate(_package);
+
+  const needsUpdate = versionLtThan(pkg.installed, pkg.latestVersion);
+  if (needsUpdate === false) {
+    return false;
+  } else if (needsUpdate === null) {
+    warn(`This script cannot determine if you have an update of ${_package} because either the installed or the latest version are betas. Please check for the update manually. Installed version: ${pkg.installed} - Latest version: ${pkg.latestVersion}`);
+    return true;
+  } else if (needsUpdate) {
+    warn(`There is an update for ${_package}. Please update to get support for the latest Tezos networks. Installed version: ${pkg.installed} - Latest version: ${pkg.latestVersion}`);
+    return true;
+  }
+
+  return false;
+}
+
+const CONFIG_FILE = path.resolve(__dirname, '../src/config.json');
+
+if (!fs.existsSync(CONFIG_FILE)) {
+  err("Unable to find src/config.json");
+}
+
+const Config = JSON.parse(fs.readFileSync(CONFIG_FILE).toString());
+if (!Config) {
+  err("src/config.json file is empty");
+}
+
+const networkKeys = Object.keys(NetworkType);
+
+const configNetwork = Config.network.name.toLowerCase();
+if (!configNetwork || configNetwork.trim() === "") {
+    err(`config.json is missing the network.name property. Please set network.name to one of: ${networkKeys.map(x => `"${NetworkType[x].toLowerCase()}"` ).join(", ")}`)
+}
+
+Config.network.networkType = undefined;
+
+const network = networkKeys.find(x => NetworkType[x].toLowerCase() === configNetwork);
+if (network) { // Happy path: config verified with success
+    console.log(chalk.green("Configuration is valid."));
+    process.exit(0);
+}
+
+// Check for newer versions?
+console.log(chalk.bold.red(`Unknown network.name "${Config.network.name}" specified in config.json.`));
+
+const airgapUpdate = suggestEventualPackageUpdate("@airgap/beacon-sdk");
+const taquitoUpdate = suggestEventualPackageUpdate("@taquito/taquito");
+
+if (!airgapUpdate && !taquitoUpdate) {
+  err(`There seems to be no updates for the Tezos network support NPM packages.\n\nPlease double check your entry, valid values are: ${networkKeys.map(x => `"${NetworkType[x].toLowerCase()}"` ).join(", ")}`);
+}
+
+process.exit(1);

--- a/src/Config.tsx
+++ b/src/Config.tsx
@@ -4,32 +4,24 @@ import { ConfigType } from "./lib/Types";
 
 let Config: ConfigType = configData;
 
-switch (Config.network.name.toLowerCase()) {
-    case "Mainnet".toLowerCase():
-        Config.network.networkType = NetworkType.MAINNET;
-        break;
-    case "Mondaynet".toLowerCase():
-        Config.network.networkType = NetworkType.MONDAYNET;
-        break;
-    case "Dailynet".toLowerCase():
-        Config.network.networkType = NetworkType.DAILYNET;
-        break;
-    case "Ithacanet".toLowerCase():
-        Config.network.networkType = NetworkType.ITHACANET;
-        break;
-    case "Jakartanet".toLowerCase():
-        Config.network.networkType = NetworkType.JAKARTANET;
-        break;
-    case "Ghostnet".toLowerCase():
-        Config.network.networkType = NetworkType.GHOSTNET;
-        break;
-    case "Kathmandunet".toLowerCase():
-        Config.network.networkType = NetworkType.KATHMANDUNET;
-        break;
-    default:
-        Config.network.networkType = undefined;
+const networkKeys = Object.keys(NetworkType) as [keyof typeof NetworkType];
+
+let configNetwork = Config.network.name;
+if (!configNetwork || configNetwork.trim() === "") {
+    throw new Error(`config.json is missing the network.name property. Please set network.name to one of: ${networkKeys.map(x => `"${NetworkType[x].toLowerCase()}"` ).join(", ")}`)
 }
 
+configNetwork = configNetwork.toLowerCase();
+
+Config.network.networkType = undefined;
+Config.application.isBeaconWallet = false;
+
+const network = networkKeys.find(x => NetworkType[x].toLowerCase() === configNetwork);
+if (!network) {
+    throw new Error(`Unknown network.name "${Config.network.name}" in config.json. If you did not make any typos, please consider updating Tezos support NPM packages to get latest networks support:\n - @airgap/beacon-sdk\n - @taquito/...`)
+}
+
+Config.network.networkType = NetworkType[network];
 Config.application.isBeaconWallet = (Config.network.networkType !== undefined);
 
 export default Config;


### PR DESCRIPTION
This PR aims to avoid that a "broken" frontend makes it to production by enforcing configuration validation.

The `src/config.json` file property `network.name` depends on `@airgap/beacon-sdk` and `@taquito/...` packages, as it is used to setup the wallet connection SDK.
This means that we have to enforce the availability of the requested network amongst the supported ones; if not present, you will be prompted to either update such packages or double-check your entry.

Such verification is performed in three ways:
- As the first step of the `build` script: this will crash compilation if you're trying to build a misconfigured client;
- As you run the app, both in dev mode and in production mode, outputting an error in the browser console
- Manually calling `npm run check-config` or `yarn check-config` from your build/deployment CLI. Command exits with error 1 if validation fails.

As a bonus, this PR also makes Config.tsx free of having to follow such networks list expansion; it now relies on the actual `@airgap/beacon-sdk`'s ```NetworkType``` so updating the dependency already adds support for new networks automatically.