### PR TITLE
switch frontend container to port 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,5 +109,5 @@ docker build . -t tezos-faucet
 
 Run Docker image:
 ```
-docker run -p 80:80 tezos-faucet
+docker run -p 8080:8080 tezos-faucet
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,4 +3,4 @@ set -e
 # We need to buid because the configuration file may be modified at runtime.
 npm run build
 
-serve -s build -p 80
+serve -s build -p 8080


### PR DESCRIPTION
since updating to kubernetes 1.27, port 80 appears to no longer work: node cannot bind to it. Fixing by making 8080 the default.

twin PR of https://github.com/oxheadalpha/tezos-k8s/pull/587